### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ To obtain a Zendesk API token, see the docs [here](https://developer.zendesk.com
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``create_ticket`` - Creates a new ticket with the given subject and description.

--- a/actions/create_ticket.yaml
+++ b/actions/create_ticket.yaml
@@ -1,5 +1,5 @@
 name: create_ticket
-runner_type: run-python
+runner_type: python-script
 description: Creates a ticket on Zendesk
 enabled: true
 entry_point: create_ticket.py

--- a/actions/search_tickets.yaml
+++ b/actions/search_tickets.yaml
@@ -1,5 +1,5 @@
 name: search_tickets
-runner_type: run-python
+runner_type: python-script
 description: Searches tickets on Zendesk
 enabled: true
 entry_point: search_tickets.py

--- a/actions/update_ticket.yaml
+++ b/actions/update_ticket.yaml
@@ -1,5 +1,5 @@
 name: update_ticket
-runner_type: run-python
+runner_type: python-script
 description: Updates a ticket on Zendesk
 enabled: true
 entry_point: update_ticket.py

--- a/actions/update_ticket_status.yaml
+++ b/actions/update_ticket_status.yaml
@@ -1,5 +1,5 @@
 name: update_ticket_status
-runner_type: run-python
+runner_type: python-script
 description: Updates the status of the zendesk ticket with the given ID
 enabled: true
 entry_point: update_ticket_status.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - zendesk
   - support
   - ticketing
-version : 0.2.0
+version : 0.3.0
 author : Casey Richardson
 email : casey@bluechasm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.